### PR TITLE
Sync with xkeyboard-config 2.45

### DIFF
--- a/rules/base
+++ b/rules/base
@@ -201,6 +201,7 @@
   $applealu	no		nodeadkeys	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l%(v)
   $applealu	pt		$mac_pt_variants	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l%(v)
   $applealu	se		nodeadkeys	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l%(v)
+  $applealu	us		applealu_iso	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l%(v)
   $applealu	$macvendorlayouts		*	=	macintosh_vndr/apple(alukbd)+%l%(v)
   $sun	$sun_custom		$sun_var	=	pc+sun_vndr/%l%(v)
   $sun	$sun_custom		*	=	pc+%l%(v)
@@ -232,6 +233,7 @@
   pc98		*			=	nec_vndr/jp(pc98)+%l%(v)
   applealu_jis	jp			=	macintosh_vndr/apple(alukbd)+macintosh_vndr/jp(usmac)+macintosh_vndr/jp(mac):2
   applealu_jis	*			=	macintosh_vndr/apple(alukbd)+%l%(v)+macintosh_vndr/jp(mac):2
+  applealu_iso	us			=	macintosh_vndr/apple(alukbd)+macintosh_vndr/us(applealu_iso)
  $applealu	$macvendorlayouts	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l
  $applealu	*			=	macintosh_vndr/apple(alukbd)+%l%(v)
   olpc		$olpclayouts		=	olpc+%l%(m)
@@ -271,6 +273,7 @@
   $applealu	no		nodeadkeys	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l[1]%(v[1])
   $applealu	pt		$mac_pt_variants	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l[1]%(v[1])
   $applealu	se		nodeadkeys	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l[1]%(v[1])
+  $applealu	us		applealu_iso	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l[1]%(v[1])
   $applealu	$macvendorlayouts		*	=	macintosh_vndr/apple(alukbd)+%l[1]%(v[1])
   $sun	$sun_custom		$sun_var	=	pc+sun_vndr/%l[1]%(v[1])
   $sun	$sun_custom		*	=	pc+%l[1]%(v[1])
@@ -294,6 +297,7 @@
   jollasbj	*			=	jolla_vndr/sbj(common)+%l[1]%(v[1])
  $sun		$sun_custom		=	pc+sun_vndr/%l[1]
   applealu_jis	us			=	macintosh_vndr/apple(alukbd)+macintosh_vndr/jp(usmac)
+  applealu_iso	us                      =       macintosh_vndr/apple(alukbd)+macintosh_vndr/us(applealu_iso)
  $applealu	$macvendorlayouts	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l[1]
  $applealu	*			=	macintosh_vndr/apple(alukbd)+%l[1]%(v[1])
  $thinkpads	br			=	pc+%l[1](thinkpad)
@@ -313,6 +317,7 @@
   *		tel			=	+in(tel):2
   *		tml			=	+in(tam):2
   *		us_intl			=	+us(alt-intl):2
+  applealu_iso	us			=	+macintosh_vndr/us(applealu_iso):2
  $applealu	$macvendorlayouts	=	+macintosh_vndr/%l[2]:2
  $sun		$sun_custom	=	+sun_vndr/%l[2]:2
   *		*		=	+%l[2]%(v[2]):2
@@ -331,6 +336,7 @@
   *		tel			=	+in(tel):3
   *		tml			=	+in(tam):3
   *		us_intl			=	+us(alt-intl):3
+  applealu_iso	us			=	+macintosh_vndr/us(applealu_iso):3
  $applealu	$macvendorlayouts	=	+macintosh_vndr/%l[3]:3
  $sun		$sun_custom	=	+sun_vndr/%l[3]:3
   *		*		=	+%l[3]%(v[3]):3
@@ -349,6 +355,7 @@
   *		tel			=	+in(tel):4
   *		tml			=	+in(tam):4
   *		us_intl			=	+us(alt-intl):4
+  applealu_iso	us			=	+macintosh_vndr/us(applealu_iso):4
  $applealu	$macvendorlayouts	=	+macintosh_vndr/%l[4]:4
  $sun		$sun_custom	=	+sun_vndr/%l[4]%(v[4]):4
   *		*		=	+%l[4]%(v[4]):4
@@ -377,6 +384,7 @@
   $applealu	no		nodeadkeys	=	+macintosh_vndr/%l[2]%(v[2]):2
   $applealu	pt		$mac_pt_variants	=	+macintosh_vndr/%l[2]%(v[2]):2
   $applealu	se		nodeadkeys	=	+macintosh_vndr/%l[2]%(v[2]):2
+  $applealu	us		applealu_iso	=	+macintosh_vndr/%l[2]%(v[2]):2
   $applealu	$macvendorlayouts		*	=	+%l[2]%(v[2]):2
   $sun	$sun_custom		$sun_var	=	+sun_vndr/%l[2]%(v[2]):2
   $sun	$sun_custom		*	=	+%l[2]%(v[2]):2
@@ -405,6 +413,7 @@
   $applealu	no		nodeadkeys	=	+macintosh_vndr/%l[3]%(v[3]):3
   $applealu	pt		$mac_pt_variants	=	+macintosh_vndr/%l[3]%(v[3]):3
   $applealu	se		nodeadkeys	=	+macintosh_vndr/%l[3]%(v[3]):3
+  $applealu	us		applealu_iso	=	+macintosh_vndr/%l[3]%(v[3]):3
   $applealu	$macvendorlayouts		*	=	+%l[3]%(v[3]):3
   $sun	$sun_custom		$sun_var	=	+sun_vndr/%l[3]%(v[3]):3
   $sun	$sun_custom		*	=	+%l[3]%(v[3]):3
@@ -433,6 +442,7 @@
   $applealu	no		nodeadkeys	=	+macintosh_vndr/%l[4]%(v[4]):4
   $applealu	pt		$mac_pt_variants	=	+macintosh_vndr/%l[4]%(v[4]):4
   $applealu	se		nodeadkeys	=	+macintosh_vndr/%l[4]%(v[4]):4
+  $applealu	us		applealu_iso	=	+macintosh_vndr/%l[4]%(v[4]):4
   $applealu	$macvendorlayouts		*	=	+%l[4]%(v[4]):4
   $sun	$sun_custom		$sun_var	=	+sun_vndr/%l[4]%(v[4]):4
   $sun	$sun_custom		*	=	+%l[4]%(v[4]):4
@@ -519,7 +529,7 @@
   de		 bone_eszett_home	= +caps(caps_lock):2+misc(assign_shift_left_action):2+level5(level5_lock):2
   de		 neo_qwertz		= +caps(caps_lock):2+misc(assign_shift_left_action):2+level5(level5_lock):2
   de		 neo_qwerty		= +caps(caps_lock):2+misc(assign_shift_left_action):2+level5(level5_lock):2
-  jp		$sun_compat		= +complete+japan(kana_lock):2
+  jp		$sun_compat		= +japan(kana_lock):2
 
 ! layout[3]	 variant[3]		= compat
   de		 neo			= +caps(caps_lock):3+misc(assign_shift_left_action):3+level5(level5_lock):3
@@ -529,7 +539,7 @@
   de		 bone_eszett_home	= +caps(caps_lock):3+misc(assign_shift_left_action):3+level5(level5_lock):3
   de		 neo_qwertz		= +caps(caps_lock):3+misc(assign_shift_left_action):3+level5(level5_lock):3
   de		 neo_qwerty		= +caps(caps_lock):3+misc(assign_shift_left_action):3+level5(level5_lock):3
-  jp		$sun_compat		= +complete+japan(kana_lock):3
+  jp		$sun_compat		= +japan(kana_lock):3
 
 ! layout[4]	 variant[4]		= compat
   de		 neo			= +caps(caps_lock):4+misc(assign_shift_left_action):4+level5(level5_lock):4
@@ -539,7 +549,7 @@
   de		 bone_eszett_home	= +caps(caps_lock):4+misc(assign_shift_left_action):4+level5(level5_lock):4
   de		 neo_qwertz		= +caps(caps_lock):4+misc(assign_shift_left_action):4+level5(level5_lock):4
   de		 neo_qwerty		= +caps(caps_lock):4+misc(assign_shift_left_action):4+level5(level5_lock):4
-  jp		$sun_compat		= +complete+japan(kana_lock):4
+  jp		$sun_compat		= +japan(kana_lock):4
 
 ! model		layout		=	compat
   pc98		jp		=	pc98(basic)
@@ -549,7 +559,17 @@
   *		*		=	complete
 
 ! model		layout[1]	=	compat
+  *		jp		=	complete+japan
   *		*		=	complete
+
+! model		layout[2]	=	compat
+  *		jp		=	+japan
+
+! model		layout[3]	=	compat
+  *		jp		=	+japan
+
+! model		layout[4]	=	compat
+  *		jp		=	+japan
 
 ! model		=	types
   $applealu	=	complete+numpad(mac)
@@ -567,7 +587,7 @@
   *		grp:ctrl_space_toggle			= +group(ctrl_space_toggle)
   *		grp:rctrl_rshift_toggle			= +group(rctrl_rshift_toggle)
   *		grp:shifts_toggle			= +group(shifts_toggle)
-  *             grp:grave_switch	=	+group(grave_switch)
+  *             grp:grave_switch        =       +group(grave_switch)
   $azerty	caps:digits_row				= +capslock(digits_row)
   $azerty	caps:digits_row_independent_lock	= +capslock(digits_row_independent_lock)
 
@@ -583,7 +603,7 @@
   *		grp:ctrl_space_toggle			= +group(ctrl_space_toggle):1
   *		grp:rctrl_rshift_toggle			= +group(rctrl_rshift_toggle):1
   *		grp:shifts_toggle			= +group(shifts_toggle):1
-  *             grp:grave_switch	=	+group(grave_switch):1
+  *             grp:grave_switch        =       +group(grave_switch)
   $azerty	caps:digits_row				= +capslock(digits_row):1
   $azerty	caps:digits_row_independent_lock	= +capslock(digits_row_independent_lock):1
 
@@ -599,7 +619,7 @@
   *		grp:ctrl_space_toggle			= +group(ctrl_space_toggle):2
   *		grp:rctrl_rshift_toggle			= +group(rctrl_rshift_toggle):2
   *		grp:shifts_toggle			= +group(shifts_toggle):2
-  *             grp:grave_switch	=	+group(grave_switch):2
+  *             grp:grave_switch        =       +group(grave_switch)
   $azerty	caps:digits_row				= +capslock(digits_row):2
   $azerty	caps:digits_row_independent_lock	= +capslock(digits_row_independent_lock):2
 
@@ -615,7 +635,7 @@
   *		grp:ctrl_space_toggle			= +group(ctrl_space_toggle):3
   *		grp:rctrl_rshift_toggle			= +group(rctrl_rshift_toggle):3
   *		grp:shifts_toggle			= +group(shifts_toggle):3
-  *             grp:grave_switch	=	+group(grave_switch):3
+  *             grp:grave_switch        =       +group(grave_switch)
   $azerty	caps:digits_row				= +capslock(digits_row):3
   $azerty	caps:digits_row_independent_lock	= +capslock(digits_row_independent_lock):3
 
@@ -631,13 +651,11 @@
   *		grp:ctrl_space_toggle			= +group(ctrl_space_toggle):4
   *		grp:rctrl_rshift_toggle			= +group(rctrl_rshift_toggle):4
   *		grp:shifts_toggle			= +group(shifts_toggle):4
-  *             grp:grave_switch        =       +group(grave_switch):4
+  *             grp:grave_switch        =       +group(grave_switch)
   $azerty	caps:digits_row				= +capslock(digits_row):4
   $azerty	caps:digits_row_independent_lock	= +capslock(digits_row_independent_lock):4
 
 ! option                         = symbols
-  grp:grave_switch        =       +group(grave_switch)
-  grp:shift_toggle	=	+group(shifts_toggle)
   grp:shift_caps_switch          = +group(caps_select)
   grp:win_menu_switch            = +group(win_menu_select)
   grp:lctrl_rctrl_switch         = +group(ctrl_select)
@@ -734,6 +752,7 @@
   grp:ctrl_shift_toggle          = +group(ctrl_shift_toggle)
   grp:ctrl_shift_toggle_bidir    = +group(ctrl_shift_toggle_bidir)
   grp:ctrls_toggle               = +group(ctrls_toggle)
+  grp:grave_switch                = +group(grave_switch)
   grp:lalt_lshift_toggle         = +group(lalt_lshift_toggle)
   grp:lalt_toggle                = +group(lalt_toggle)
   grp:lctrl_lalt_toggle          = +group(lctrl_lalt_toggle)
@@ -759,6 +778,8 @@
   grp:switch                     = +group(switch)
   grp:win_menu_select            = +group(win_menu_select)
   grp:win_switch                 = +group(win_switch)
+  hyper:mod3                     = +hyper(mod3)
+  hyper:mod4                     = +hyper(mod4)
   japan:hztg_escape              = +jp(hztg_escape)
   japan:nicola_f_bs              = +jp(nicola_f_bs)
   keypad:atm                     = +keypad(atm)

--- a/rules/base.lst
+++ b/rules/base.lst
@@ -608,7 +608,6 @@
   scn             it: Sicilian
   geo             it: Georgian (Italy)
   kana            jp: Japanese (Kana)
-  kana86          jp: Japanese (Kana 86)
   OADG109A        jp: Japanese (OADG 109A)
   mac             jp: Japanese (Macintosh)
   dvorak          jp: Japanese (Dvorak)
@@ -743,6 +742,7 @@
   dvorak          se: Swedish (Dvorak)
   us_dvorak       se: Swedish (Dvorak, intl.)
   svdvorak        se: Swedish (Svdvorak)
+  colemak         se: Swedish (Colemak)
   mac             se: Swedish (Macintosh)
   us              se: Swedish (US)
   swl             se: Swedish Sign Language
@@ -780,7 +780,6 @@
 
 ! option
   grp                  Switching to another layout
-  grp:grave_switch     Grave switches layout.
   grp:switch           Right Alt (while pressed)
   grp:lswitch          Left Alt (while pressed)
   grp:lwin_switch      Left Win (while pressed)
@@ -801,6 +800,7 @@
   grp:alts_toggle      Both Alts together
   grp:alt_altgr_toggle Both Alts together; AltGr alone chooses third level
   grp:ctrls_toggle     Both Ctrls together
+  grp:grave_switch     Grave switches layout.
   grp:ctrl_shift_toggle Ctrl+Shift
   grp:lctrl_lshift_toggle Left Ctrl+Left Shift
   grp:rctrl_rshift_toggle Right Ctrl+Right Shift
@@ -949,6 +949,8 @@
   numpad:mac           Numeric keypad always enters digits (as in macOS)
   numpad:microsoft     Num Lock on: digits; Shift for arrows. Num Lock off: arrows (as in Windows)
   numpad:shift3        Shift does not cancel Num Lock, chooses 3rd level instead
+  hyper:mod3           Map Hyper to Mod3 (conflict with LevelFive)
+  hyper:mod4           Map Hyper to Mod4 (conflict with Super)
   scrolllock:mod3      Map Scroll Lock to Mod3
   srvrkeys:none        Special keys (Ctrl+Alt+&lt;key&gt;) handled in a server
   apple:alupckeys      Apple Aluminium emulates Pause, PrtSc, Scroll Lock

--- a/rules/base.xml
+++ b/rules/base.xml
@@ -4958,12 +4958,6 @@
         </variant>
         <variant>
           <configItem>
-            <name>kana86</name>
-            <description>Japanese (Kana 86)</description>
-          </configItem>
-        </variant>
-        <variant>
-          <configItem>
             <name>OADG109A</name>
             <description>Japanese (OADG 109A)</description>
           </configItem>
@@ -6434,6 +6428,12 @@
         </variant>
         <variant>
           <configItem>
+            <name>colemak</name>
+            <description>Swedish (Colemak)</description>
+          </configItem>
+        </variant>
+        <variant>
+          <configItem>
             <name>mac</name>
             <description>Swedish (Macintosh)</description>
           </configItem>
@@ -6912,7 +6912,7 @@
         <name>grp</name>
         <description>Switching to another layout</description>
       </configItem>
-     <option>
+      <option>
         <configItem>
           <name>grp:grave_switch</name>
           <description>Grave switches layout.</description>
@@ -7941,6 +7941,18 @@
         <configItem>
           <name>numpad:shift3</name>
           <description>Shift does not cancel Num Lock, chooses 3rd level instead</description>
+        </configItem>
+      </option>
+      <option>
+        <configItem>
+          <name>hyper:mod3</name>
+          <description>Map Hyper to Mod3 (conflict with LevelFive)</description>
+        </configItem>
+      </option>
+      <option>
+        <configItem>
+          <name>hyper:mod4</name>
+          <description>Map Hyper to Mod4 (conflict with Super)</description>
         </configItem>
       </option>
       <option>

--- a/rules/evdev
+++ b/rules/evdev
@@ -142,6 +142,7 @@
   $applealu	no		nodeadkeys	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l%(v)
   $applealu	pt		$mac_pt_variants	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l%(v)
   $applealu	se		nodeadkeys	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l%(v)
+  $applealu	us		applealu_iso	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l%(v)
   $applealu	$macvendorlayouts		*	=	macintosh_vndr/apple(alukbd)+%l%(v)
   $sun	$sun_custom		$sun_var	=	pc+sun_vndr/%l%(v)
   $sun	$sun_custom		*	=	pc+%l%(v)
@@ -173,6 +174,7 @@
   pc98		*			=	nec_vndr/jp(pc98)+%l%(v)
   applealu_jis	jp			=	macintosh_vndr/apple(alukbd)+macintosh_vndr/jp(usmac)+macintosh_vndr/jp(mac):2
   applealu_jis	*			=	macintosh_vndr/apple(alukbd)+%l%(v)+macintosh_vndr/jp(mac):2
+  applealu_iso	us			=	macintosh_vndr/apple(alukbd)+macintosh_vndr/us(applealu_iso)
  $applealu	$macvendorlayouts	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l
  $applealu	*			=	macintosh_vndr/apple(alukbd)+%l%(v)
   olpc		$olpclayouts		=	olpc+%l%(m)
@@ -212,6 +214,7 @@
   $applealu	no		nodeadkeys	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l[1]%(v[1])
   $applealu	pt		$mac_pt_variants	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l[1]%(v[1])
   $applealu	se		nodeadkeys	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l[1]%(v[1])
+  $applealu	us		applealu_iso	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l[1]%(v[1])
   $applealu	$macvendorlayouts		*	=	macintosh_vndr/apple(alukbd)+%l[1]%(v[1])
   $sun	$sun_custom		$sun_var	=	pc+sun_vndr/%l[1]%(v[1])
   $sun	$sun_custom		*	=	pc+%l[1]%(v[1])
@@ -235,6 +238,7 @@
   jollasbj	*			=	jolla_vndr/sbj(common)+%l[1]%(v[1])
  $sun		$sun_custom		=	pc+sun_vndr/%l[1]
   applealu_jis	us			=	macintosh_vndr/apple(alukbd)+macintosh_vndr/jp(usmac)
+  applealu_iso	us                      =       macintosh_vndr/apple(alukbd)+macintosh_vndr/us(applealu_iso)
  $applealu	$macvendorlayouts	=	macintosh_vndr/apple(alukbd)+macintosh_vndr/%l[1]
  $applealu	*			=	macintosh_vndr/apple(alukbd)+%l[1]%(v[1])
  $thinkpads	br			=	pc+%l[1](thinkpad)
@@ -254,6 +258,7 @@
   *		tel			=	+in(tel):2
   *		tml			=	+in(tam):2
   *		us_intl			=	+us(alt-intl):2
+  applealu_iso	us			=	+macintosh_vndr/us(applealu_iso):2
  $applealu	$macvendorlayouts	=	+macintosh_vndr/%l[2]:2
  $sun		$sun_custom	=	+sun_vndr/%l[2]:2
   *		*		=	+%l[2]%(v[2]):2
@@ -272,6 +277,7 @@
   *		tel			=	+in(tel):3
   *		tml			=	+in(tam):3
   *		us_intl			=	+us(alt-intl):3
+  applealu_iso	us			=	+macintosh_vndr/us(applealu_iso):3
  $applealu	$macvendorlayouts	=	+macintosh_vndr/%l[3]:3
  $sun		$sun_custom	=	+sun_vndr/%l[3]:3
   *		*		=	+%l[3]%(v[3]):3
@@ -290,6 +296,7 @@
   *		tel			=	+in(tel):4
   *		tml			=	+in(tam):4
   *		us_intl			=	+us(alt-intl):4
+  applealu_iso	us			=	+macintosh_vndr/us(applealu_iso):4
  $applealu	$macvendorlayouts	=	+macintosh_vndr/%l[4]:4
  $sun		$sun_custom	=	+sun_vndr/%l[4]%(v[4]):4
   *		*		=	+%l[4]%(v[4]):4
@@ -318,6 +325,7 @@
   $applealu	no		nodeadkeys	=	+macintosh_vndr/%l[2]%(v[2]):2
   $applealu	pt		$mac_pt_variants	=	+macintosh_vndr/%l[2]%(v[2]):2
   $applealu	se		nodeadkeys	=	+macintosh_vndr/%l[2]%(v[2]):2
+  $applealu	us		applealu_iso	=	+macintosh_vndr/%l[2]%(v[2]):2
   $applealu	$macvendorlayouts		*	=	+%l[2]%(v[2]):2
   $sun	$sun_custom		$sun_var	=	+sun_vndr/%l[2]%(v[2]):2
   $sun	$sun_custom		*	=	+%l[2]%(v[2]):2
@@ -346,6 +354,7 @@
   $applealu	no		nodeadkeys	=	+macintosh_vndr/%l[3]%(v[3]):3
   $applealu	pt		$mac_pt_variants	=	+macintosh_vndr/%l[3]%(v[3]):3
   $applealu	se		nodeadkeys	=	+macintosh_vndr/%l[3]%(v[3]):3
+  $applealu	us		applealu_iso	=	+macintosh_vndr/%l[3]%(v[3]):3
   $applealu	$macvendorlayouts		*	=	+%l[3]%(v[3]):3
   $sun	$sun_custom		$sun_var	=	+sun_vndr/%l[3]%(v[3]):3
   $sun	$sun_custom		*	=	+%l[3]%(v[3]):3
@@ -374,6 +383,7 @@
   $applealu	no		nodeadkeys	=	+macintosh_vndr/%l[4]%(v[4]):4
   $applealu	pt		$mac_pt_variants	=	+macintosh_vndr/%l[4]%(v[4]):4
   $applealu	se		nodeadkeys	=	+macintosh_vndr/%l[4]%(v[4]):4
+  $applealu	us		applealu_iso	=	+macintosh_vndr/%l[4]%(v[4]):4
   $applealu	$macvendorlayouts		*	=	+%l[4]%(v[4]):4
   $sun	$sun_custom		$sun_var	=	+sun_vndr/%l[4]%(v[4]):4
   $sun	$sun_custom		*	=	+%l[4]%(v[4]):4
@@ -411,7 +421,7 @@
   de		 bone_eszett_home	= +caps(caps_lock):2+misc(assign_shift_left_action):2+level5(level5_lock):2
   de		 neo_qwertz		= +caps(caps_lock):2+misc(assign_shift_left_action):2+level5(level5_lock):2
   de		 neo_qwerty		= +caps(caps_lock):2+misc(assign_shift_left_action):2+level5(level5_lock):2
-  jp		$sun_compat		= +complete+japan(kana_lock):2
+  jp		$sun_compat		= +japan(kana_lock):2
 
 ! layout[3]	 variant[3]		= compat
   de		 neo			= +caps(caps_lock):3+misc(assign_shift_left_action):3+level5(level5_lock):3
@@ -421,7 +431,7 @@
   de		 bone_eszett_home	= +caps(caps_lock):3+misc(assign_shift_left_action):3+level5(level5_lock):3
   de		 neo_qwertz		= +caps(caps_lock):3+misc(assign_shift_left_action):3+level5(level5_lock):3
   de		 neo_qwerty		= +caps(caps_lock):3+misc(assign_shift_left_action):3+level5(level5_lock):3
-  jp		$sun_compat		= +complete+japan(kana_lock):3
+  jp		$sun_compat		= +japan(kana_lock):3
 
 ! layout[4]	 variant[4]		= compat
   de		 neo			= +caps(caps_lock):4+misc(assign_shift_left_action):4+level5(level5_lock):4
@@ -431,7 +441,7 @@
   de		 bone_eszett_home	= +caps(caps_lock):4+misc(assign_shift_left_action):4+level5(level5_lock):4
   de		 neo_qwertz		= +caps(caps_lock):4+misc(assign_shift_left_action):4+level5(level5_lock):4
   de		 neo_qwerty		= +caps(caps_lock):4+misc(assign_shift_left_action):4+level5(level5_lock):4
-  jp		$sun_compat		= +complete+japan(kana_lock):4
+  jp		$sun_compat		= +japan(kana_lock):4
 
 ! model		layout		=	compat
   pc98		jp		=	pc98(basic)
@@ -441,7 +451,17 @@
   *		*		=	complete
 
 ! model		layout[1]	=	compat
+  *		jp		=	complete+japan
   *		*		=	complete
+
+! model		layout[2]	=	compat
+  *		jp		=	+japan
+
+! model		layout[3]	=	compat
+  *		jp		=	+japan
+
+! model		layout[4]	=	compat
+  *		jp		=	+japan
 
 ! model		=	types
   $applealu	=	complete+numpad(mac)
@@ -475,7 +495,7 @@
   *		grp:ctrl_space_toggle			= +group(ctrl_space_toggle):1
   *		grp:rctrl_rshift_toggle			= +group(rctrl_rshift_toggle):1
   *		grp:shifts_toggle			= +group(shifts_toggle):1
-  *             grp:grave_switch        =       +group(grave_switch):1
+  *             grp:grave_switch        =       +group(grave_switch)
   $azerty	caps:digits_row				= +capslock(digits_row):1
   $azerty	caps:digits_row_independent_lock	= +capslock(digits_row_independent_lock):1
 
@@ -491,7 +511,7 @@
   *		grp:ctrl_space_toggle			= +group(ctrl_space_toggle):2
   *		grp:rctrl_rshift_toggle			= +group(rctrl_rshift_toggle):2
   *		grp:shifts_toggle			= +group(shifts_toggle):2
-  *             grp:grave_switch        =       +group(grave_switch):2
+  *             grp:grave_switch        =       +group(grave_switch)
   $azerty	caps:digits_row				= +capslock(digits_row):2
   $azerty	caps:digits_row_independent_lock	= +capslock(digits_row_independent_lock):2
 
@@ -507,7 +527,7 @@
   *		grp:ctrl_space_toggle			= +group(ctrl_space_toggle):3
   *		grp:rctrl_rshift_toggle			= +group(rctrl_rshift_toggle):3
   *		grp:shifts_toggle			= +group(shifts_toggle):3
-  *             grp:grave_switch        =       +group(grave_switch):3
+  *             grp:grave_switch        =       +group(grave_switch)
   $azerty	caps:digits_row				= +capslock(digits_row):3
   $azerty	caps:digits_row_independent_lock	= +capslock(digits_row_independent_lock):3
 
@@ -523,13 +543,11 @@
   *		grp:ctrl_space_toggle			= +group(ctrl_space_toggle):4
   *		grp:rctrl_rshift_toggle			= +group(rctrl_rshift_toggle):4
   *		grp:shifts_toggle			= +group(shifts_toggle):4
-  *             grp:grave_switch        =       +group(grave_switch):4
+  *             grp:grave_switch        =       +group(grave_switch)
   $azerty	caps:digits_row				= +capslock(digits_row):4
   $azerty	caps:digits_row_independent_lock	= +capslock(digits_row_independent_lock):4
 
 ! option                         = symbols
-  grp:grave_switch        =       +group(grave_switch)
-  grp:shift_toggle	=	+group(shifts_toggle)
   grp:shift_caps_switch          = +group(caps_select)
   grp:win_menu_switch            = +group(win_menu_select)
   grp:lctrl_rctrl_switch         = +group(ctrl_select)
@@ -626,6 +644,7 @@
   grp:ctrl_shift_toggle          = +group(ctrl_shift_toggle)
   grp:ctrl_shift_toggle_bidir    = +group(ctrl_shift_toggle_bidir)
   grp:ctrls_toggle               = +group(ctrls_toggle)
+  grp:grave_switch                = +group(grave_switch)
   grp:lalt_lshift_toggle         = +group(lalt_lshift_toggle)
   grp:lalt_toggle                = +group(lalt_toggle)
   grp:lctrl_lalt_toggle          = +group(lctrl_lalt_toggle)
@@ -651,6 +670,8 @@
   grp:switch                     = +group(switch)
   grp:win_menu_select            = +group(win_menu_select)
   grp:win_switch                 = +group(win_switch)
+  hyper:mod3                     = +hyper(mod3)
+  hyper:mod4                     = +hyper(mod4)
   japan:hztg_escape              = +jp(hztg_escape)
   japan:nicola_f_bs              = +jp(nicola_f_bs)
   keypad:atm                     = +keypad(atm)

--- a/rules/evdev.lst
+++ b/rules/evdev.lst
@@ -608,7 +608,6 @@
   scn             it: Sicilian
   geo             it: Georgian (Italy)
   kana            jp: Japanese (Kana)
-  kana86          jp: Japanese (Kana 86)
   OADG109A        jp: Japanese (OADG 109A)
   mac             jp: Japanese (Macintosh)
   dvorak          jp: Japanese (Dvorak)
@@ -743,6 +742,7 @@
   dvorak          se: Swedish (Dvorak)
   us_dvorak       se: Swedish (Dvorak, intl.)
   svdvorak        se: Swedish (Svdvorak)
+  colemak         se: Swedish (Colemak)
   mac             se: Swedish (Macintosh)
   us              se: Swedish (US)
   swl             se: Swedish Sign Language
@@ -780,7 +780,6 @@
 
 ! option
   grp                  Switching to another layout
-  grp:grave_switch     Grave switches layout.
   grp:switch           Right Alt (while pressed)
   grp:lswitch          Left Alt (while pressed)
   grp:lwin_switch      Left Win (while pressed)
@@ -801,6 +800,7 @@
   grp:alts_toggle      Both Alts together
   grp:alt_altgr_toggle Both Alts together; AltGr alone chooses third level
   grp:ctrls_toggle     Both Ctrls together
+  grp:grave_switch     Grave switches layout.
   grp:ctrl_shift_toggle Ctrl+Shift
   grp:lctrl_lshift_toggle Left Ctrl+Left Shift
   grp:rctrl_rshift_toggle Right Ctrl+Right Shift
@@ -949,6 +949,8 @@
   numpad:mac           Numeric keypad always enters digits (as in macOS)
   numpad:microsoft     Num Lock on: digits; Shift for arrows. Num Lock off: arrows (as in Windows)
   numpad:shift3        Shift does not cancel Num Lock, chooses 3rd level instead
+  hyper:mod3           Map Hyper to Mod3 (conflict with LevelFive)
+  hyper:mod4           Map Hyper to Mod4 (conflict with Super)
   scrolllock:mod3      Map Scroll Lock to Mod3
   srvrkeys:none        Special keys (Ctrl+Alt+&lt;key&gt;) handled in a server
   apple:alupckeys      Apple Aluminium emulates Pause, PrtSc, Scroll Lock

--- a/rules/evdev.xml
+++ b/rules/evdev.xml
@@ -4958,12 +4958,6 @@
         </variant>
         <variant>
           <configItem>
-            <name>kana86</name>
-            <description>Japanese (Kana 86)</description>
-          </configItem>
-        </variant>
-        <variant>
-          <configItem>
             <name>OADG109A</name>
             <description>Japanese (OADG 109A)</description>
           </configItem>
@@ -6430,6 +6424,12 @@
           <configItem>
             <name>svdvorak</name>
             <description>Swedish (Svdvorak)</description>
+          </configItem>
+        </variant>
+        <variant>
+          <configItem>
+            <name>colemak</name>
+            <description>Swedish (Colemak)</description>
           </configItem>
         </variant>
         <variant>
@@ -7941,6 +7941,18 @@
         <configItem>
           <name>numpad:shift3</name>
           <description>Shift does not cancel Num Lock, chooses 3rd level instead</description>
+        </configItem>
+      </option>
+      <option>
+        <configItem>
+          <name>hyper:mod3</name>
+          <description>Map Hyper to Mod3 (conflict with LevelFive)</description>
+        </configItem>
+      </option>
+      <option>
+        <configItem>
+          <name>hyper:mod4</name>
+          <description>Map Hyper to Mod4 (conflict with Super)</description>
         </configItem>
       </option>
       <option>


### PR DESCRIPTION
## Summary
- sync rules with xkeyboard-config 2.45
- keep custom `grp:grave_switch` option

## Testing
- `meson setup build --prefix=/tmp/xkb-install`
- `meson compile -C build`
- `meson install -C build`